### PR TITLE
automatically create directories recursively

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -1,5 +1,7 @@
 package goldie
 
+import "fmt"
+
 // errFixtureNotFound is thrown when the fixture file could not be found.
 type errFixtureNotFound struct {
 	message string
@@ -32,4 +34,20 @@ func newErrFixtureMismatch(message string) errFixtureMismatch {
 
 func (e errFixtureMismatch) Error() string {
 	return e.message
+}
+
+// errFixtureDirecetoryIsFile is thrown when the fixture directory is a file
+type errFixtureDirectoryIsFile struct {
+	file string
+}
+
+// newFixtureDirectoryIsFile returns a new instance of the error.
+func newErrFixtureDirectoryIsFile(file string) errFixtureDirectoryIsFile {
+	return errFixtureDirectoryIsFile{
+		file: file,
+	}
+}
+
+func (e errFixtureDirectoryIsFile) Error() string {
+	return fmt.Sprintf("fixture folder is a file: %s", e.file)
 }

--- a/errors_test.go
+++ b/errors_test.go
@@ -21,3 +21,12 @@ func TestErrFixtureMismatch(t *testing.T) {
 	assert.Equal(t, message, err.Error())
 	assert.IsType(t, errFixtureMismatch{}, err)
 }
+
+func TestErrFixtureDirectoryIsFile(t *testing.T) {
+	message := "fixture folder is a file: some/location/thing"
+	location := "some/location/thing"
+	err := newErrFixtureDirectoryIsFile(location)
+
+	assert.Equal(t, message, err.Error())
+	assert.IsType(t, errFixtureDirectoryIsFile{}, err)
+}

--- a/goldie.go
+++ b/goldie.go
@@ -123,7 +123,7 @@ func ensureDir(loc string) error {
 	}
 
 	if os.IsNotExist(err) {
-		err = os.Mkdir(loc, DirPerms)
+		err = os.MkdirAll(loc, DirPerms)
 		if err != nil {
 			return err
 		}

--- a/goldie.go
+++ b/goldie.go
@@ -78,7 +78,7 @@ func Assert(t *testing.T, name string, actualData []byte) {
 // can be explicitly called if needed. The more common approach would be to
 // update using `go test -update ./...`.
 func Update(name string, actualData []byte) error {
-	err := ensureFixtureDir()
+	err := ensureDir(FixtureDir)
 	if err != nil {
 		return err
 	}
@@ -116,14 +116,14 @@ func compare(name string, actualData []byte) error {
 }
 
 // ensureFixtureDir will create the fixture folder if it does not already exist.
-func ensureFixtureDir() error {
-	_, err := os.Stat(FixtureDir)
+func ensureDir(loc string) error {
+	_, err := os.Stat(loc)
 	if err == nil {
 		return nil
 	}
 
 	if os.IsNotExist(err) {
-		err = os.Mkdir(FixtureDir, DirPerms)
+		err = os.Mkdir(loc, DirPerms)
 		if err != nil {
 			return err
 		}

--- a/goldie.go
+++ b/goldie.go
@@ -83,12 +83,12 @@ func Update(name string, actualData []byte) error {
 		return err
 	}
 
-	err = ioutil.WriteFile(goldenFileName(name), actualData, FilePerms)
-	if err != nil {
-		return err
-	}
+	// if err = ensureDir(goldenFileName(name)); err != nil {
+	// 	return err
+	// }
 
-	return nil
+	err = ioutil.WriteFile(goldenFileName(name), actualData, FilePerms)
+	return err
 }
 
 // compare is reading the golden fixture file and compate the stored data with
@@ -117,19 +117,20 @@ func compare(name string, actualData []byte) error {
 
 // ensureFixtureDir will create the fixture folder if it does not already exist.
 func ensureDir(loc string) error {
-	_, err := os.Stat(loc)
-	if err == nil {
-		return nil
-	}
-
-	if os.IsNotExist(err) {
+	s, err := os.Stat(loc)
+	switch {
+	case err != nil && os.IsNotExist(err):
+		// the location does not exist, so make directories to there
 		err = os.MkdirAll(loc, DirPerms)
 		if err != nil {
 			return err
 		}
+		return err
+	case err == nil && !s.IsDir():
+		return newErrFixtureDirectoryIsFile(loc)
+	default:
+		return err
 	}
-
-	return err
 }
 
 // goldenFileName simply returns the file name of the golden file fixture.

--- a/goldie_test.go
+++ b/goldie_test.go
@@ -56,7 +56,7 @@ func TestGoldenFileName(t *testing.T) {
 	}
 }
 
-func TestEnsureFixtureDir(t *testing.T) {
+func TestEnsureDir(t *testing.T) {
 	tests := []struct {
 		dir         string
 		shouldExist bool
@@ -80,23 +80,18 @@ func TestEnsureFixtureDir(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		oldFixtureDir := FixtureDir
-		FixtureDir = test.dir
-
 		if test.shouldExist {
 			err := os.Mkdir(test.dir, 0755)
 			assert.Nil(t, err)
 		}
 
-		err := ensureFixtureDir()
+		err := ensureDir(test.dir)
 		assert.IsType(t, test.err, err)
 
 		if err == nil {
 			err = os.RemoveAll(test.dir)
 			assert.Nil(t, err)
 		}
-
-		FixtureDir = oldFixtureDir
 	}
 }
 

--- a/goldie_test.go
+++ b/goldie_test.go
@@ -73,9 +73,9 @@ func TestEnsureDir(t *testing.T) {
 			err:         nil,
 		},
 		{
-			dir:         "\"24348q0980fd/&&**D&S**SS:",
-			shouldExist: false,
-			err:         &os.PathError{},
+			dir:         "now/still/works",
+			shouldExist: true,
+			err:         nil,
 		},
 	}
 


### PR DESCRIPTION
This PR expands on goldie's directory creation.

* Previously, goldie only created the FixtureDir if it did not exist, and did not create parent directories - only creating the last directory. Now, foldie will create the FixtureDir along with any required parents.
* goldie now creates directories within the FixtureDir for required subtests.
* goldie now reports a distinct error if the FixtureDir or directory to hold the .golden output is a file instead of a folder.
* goldie does not currently report if parent folder to the final folder is a file - I may see about changing that.
* Because I switched from `os.Mkdir()` to `os.MkdirAll()` goldie loses one line of test coverage - the previous error tripped when a parent folder did not exist.
* Switched tests `TestEnsureFixtureDir()`/`TestEnsureDir()` so that it now uses a temp folder, and does not clean that up.