### PR TITLE
Restructuring of package plus diff generation and new errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ what is present in the golden test file.
 
 ```
 func TestExample(t *testing.T) {
+    g := goldie.New(t)
     recorder := httptest.NewRecorder()
 
     req, err := http.NewRequest("GET", "/example", nil)
@@ -32,14 +33,14 @@ func TestExample(t *testing.T) {
     handler := http.HandlerFunc(ExampleHandler)
     handler.ServeHTTP()
 
-    goldie.Assert(t, "example", recorder.Body.Bytes())
+    g.Assert(t, "example", recorder.Body.Bytes())
 }
 ```
 
 ## Using template golden file
 
 If some values in the golden file can change depending on the test, you can use golang
-template in the golden file and pass the data to `goldie.AssertWithTemplate`.
+template in the golden file and pass the data to `AssertWithTemplate`.
 
 ### example.golden
 ```
@@ -49,6 +50,8 @@ This is a {{ .Type }} file.
 ### Test
 ```
 func TestTemplateExample(t *testing.T) {
+    g := goldie.New(t)
+
     recorder := httptest.NewRecorder()
 
     req, err := http.NewRequest("POST", "/example/Golden", nil)
@@ -63,7 +66,7 @@ func TestTemplateExample(t *testing.T) {
         Type:	"Golden",
     }
 
-    goldie.AssertWithTemplate(t, "example", data, recorder.Body.Bytes())
+    g.AssertWithTemplate(t, "example", data, recorder.Body.Bytes())
 }
 ```
 
@@ -76,6 +79,25 @@ drop the `-update` flag.
 
 `go test ./...`
 
+## Options
+`goldie` supports a number of configuration options that will alter the behavior
+of the library.  These options should be passed into the `goldie.New()` method.
+
+```
+func TestNewExample(t *testing.T) {
+    g := goldie.New(
+        t,
+        goldie.WithFixtureDir("test-fixtures"),
+        goldie.WithNameSuffix(".golden.json"),
+        goldie.WithDiffEngine(goldie.ColoredDiff),
+        goldie.WithTestNameForDir(true),
+    )
+
+    g.Assert(t, "example", "my example data")
+}
+
+```
+
 ## FAQ
 
 ### Do you need any help in the project?
@@ -83,7 +105,6 @@ drop the `-update` flag.
 Yes, please! Pull requests are most welcome. On the wish list:
 
 - Unit tests.
-- Better output for failed tests. A diff of some sort would be great.
 
 ### Why the name `goldie`?
 

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ func TestNewExample(t *testing.T) {
         goldie.WithTestNameForDir(true),
     )
 
-    g.Assert(t, "example", "my example data")
+    g.Assert(t, "example", []byte("my example data"))
 }
 
 ```

--- a/errors.go
+++ b/errors.go
@@ -8,14 +8,15 @@ type errFixtureNotFound struct {
 }
 
 // newErrFixtureNotFound returns a new instance of the error.
-func newErrFixtureNotFound() errFixtureNotFound {
-	return errFixtureNotFound{
+func newErrFixtureNotFound() *errFixtureNotFound {
+	return &errFixtureNotFound{
+		// TODO: flag name should be based on the variable value
 		message: "Golden fixture not found. Try running with -update flag.",
 	}
 }
 
 // Error returns the error message.
-func (e errFixtureNotFound) Error() string {
+func (e *errFixtureNotFound) Error() string {
 	return e.message
 }
 
@@ -26,13 +27,13 @@ type errFixtureMismatch struct {
 }
 
 // newErrFixtureMismatch returns a new instance of the error.
-func newErrFixtureMismatch(message string) errFixtureMismatch {
-	return errFixtureMismatch{
+func newErrFixtureMismatch(message string) *errFixtureMismatch {
+	return &errFixtureMismatch{
 		message: message,
 	}
 }
 
-func (e errFixtureMismatch) Error() string {
+func (e *errFixtureMismatch) Error() string {
 	return e.message
 }
 
@@ -42,12 +43,32 @@ type errFixtureDirectoryIsFile struct {
 }
 
 // newFixtureDirectoryIsFile returns a new instance of the error.
-func newErrFixtureDirectoryIsFile(file string) errFixtureDirectoryIsFile {
-	return errFixtureDirectoryIsFile{
+func newErrFixtureDirectoryIsFile(file string) *errFixtureDirectoryIsFile {
+	return &errFixtureDirectoryIsFile{
 		file: file,
 	}
 }
 
-func (e errFixtureDirectoryIsFile) Error() string {
+func (e *errFixtureDirectoryIsFile) Error() string {
 	return fmt.Sprintf("fixture folder is a file: %s", e.file)
+}
+
+func (e *errFixtureDirectoryIsFile) File() string {
+	return e.file
+}
+
+// errMissingKey is thrown when a value for a template is missing
+type errMissingKey struct {
+	message string
+}
+
+// newErrMissingKey returns a new instance of the error.
+func newErrMissingKey(message string) *errMissingKey {
+	return &errMissingKey{
+		message: message,
+	}
+}
+
+func (e *errMissingKey) Error() string {
+	return e.message
 }

--- a/errors_test.go
+++ b/errors_test.go
@@ -11,7 +11,7 @@ func TestErrFixtureNotFound(t *testing.T) {
 	err := newErrFixtureNotFound()
 
 	assert.Equal(t, expected, err.Error())
-	assert.IsType(t, errFixtureNotFound{}, err)
+	assert.IsType(t, &errFixtureNotFound{}, err)
 }
 
 func TestErrFixtureMismatch(t *testing.T) {
@@ -19,7 +19,7 @@ func TestErrFixtureMismatch(t *testing.T) {
 	err := newErrFixtureMismatch(message)
 
 	assert.Equal(t, message, err.Error())
-	assert.IsType(t, errFixtureMismatch{}, err)
+	assert.IsType(t, &errFixtureMismatch{}, err)
 }
 
 func TestErrFixtureDirectoryIsFile(t *testing.T) {
@@ -28,5 +28,5 @@ func TestErrFixtureDirectoryIsFile(t *testing.T) {
 	err := newErrFixtureDirectoryIsFile(location)
 
 	assert.Equal(t, message, err.Error())
-	assert.IsType(t, errFixtureDirectoryIsFile{}, err)
+	assert.IsType(t, &errFixtureDirectoryIsFile{}, err)
 }

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,9 @@ module github.com/sebdah/goldie
 
 go 1.12
 
-require github.com/stretchr/testify v1.3.0
+require (
+	github.com/pkg/errors v0.8.1
+	github.com/pmezard/go-difflib v1.0.0
+	github.com/sergi/go-diff v1.0.0
+	github.com/stretchr/testify v1.3.0
+)

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,11 @@
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
+github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/sergi/go-diff v1.0.0 h1:Kpca3qRNrduNnOQeazBd0ysaKrUJiIuISHxogkT9RPQ=
+github.com/sergi/go-diff v1.0.0/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAmXWZgo=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=

--- a/goldie.go
+++ b/goldie.go
@@ -25,6 +25,10 @@ import (
 	"github.com/sergi/go-diff/diffmatchpatch"
 )
 
+// Compile time assurance
+var _ Tester = &goldie{}
+var _ OptionProcessor = &goldie{}
+
 type goldie struct {
 	fixtureDir     string
 	fileNameSuffix string

--- a/goldie.go
+++ b/goldie.go
@@ -11,38 +11,79 @@ package goldie
 import (
 	"bytes"
 	"encoding/json"
-	"flag"
 	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"text/template"
+
+	"errors"
+
+	"github.com/pmezard/go-difflib/difflib"
+	"github.com/sergi/go-diff/diffmatchpatch"
 )
 
-var (
-	// FixtureDir is the folder name for where the fixtures are stored. It's
-	// relative to the "go test" path.
-	FixtureDir = "fixtures"
+type goldie struct {
+	fixtureDir     string
+	fileNameSuffix string
+	filePerms      os.FileMode
+	dirPerms       os.FileMode
 
-	// FileNameSuffix is the suffix appended to the fixtures. Set to empty
-	// string to disable file name suffixes.
-	FileNameSuffix = ".golden"
+	diffProcessor        DiffProcessor
+	diffFn               DiffFn
+	ignoreTemplateErrors bool
+	useTestNameForDir    bool
+	useSubTestNameForDir bool
+}
 
-	// FlagName is the name of the command line flag for go test.
-	FlagName = "update"
+// === OptionProcessor ===============================
 
-	// FilePerms is used to set the permissions on the golden fixture files.
-	FilePerms os.FileMode = 0644
+func (g *goldie) WithFixtureDir(dir string) error {
+	g.fixtureDir = dir
+	return nil
+}
 
-	// DirPerms is used to set the permissions on the golden fixture folder.
-	DirPerms os.FileMode = 0755
+func (g *goldie) WithNameSuffix(suffix string) error {
+	g.fileNameSuffix = suffix
+	return nil
+}
 
-	// update determines if the actual received data should be written to the
-	// golden files or not. This should be true when you need to update the
-	// data, but false when actually running the tests.
-	update = flag.Bool(FlagName, false, "Update golden test file fixture")
-)
+func (g *goldie) WithFilePerms(mode os.FileMode) error {
+	g.filePerms = mode
+	return nil
+}
+
+func (g *goldie) WithDirPerms(mode os.FileMode) error {
+	g.dirPerms = mode
+	return nil
+}
+
+func (g *goldie) WithDiffEngine(engine DiffProcessor) error {
+	g.diffProcessor = engine
+	return nil
+}
+
+func (g *goldie) WithDiffFn(fn DiffFn) error {
+	g.diffFn = fn
+	return nil
+}
+
+func (g *goldie) WithIgnoreTemplateErrors(ignoreErrors bool) error {
+	g.ignoreTemplateErrors = ignoreErrors
+	return nil
+}
+
+func (g *goldie) WithTestNameForDir(use bool) error {
+	g.useTestNameForDir = use
+	return nil
+}
+
+func (g *goldie) WithSubTestNameForDir(use bool) error {
+	g.useSubTestNameForDir = use
+	return nil
+}
 
 // Assert compares the actual data received with the expected data in the
 // golden files. If the update flag is set, it will also update the golden
@@ -51,26 +92,35 @@ var (
 // `name` refers to the name of the test and it should typically be unique
 // within the package. Also it should be a valid file name (so keeping to
 // `a-z0-9\-\_` is a good idea).
-func Assert(t *testing.T, name string, actualData []byte) {
+func (g *goldie) Assert(t *testing.T, name string, actualData []byte) {
 	if *update {
-		err := Update(name, actualData)
+		err := g.Update(t, name, actualData)
 		if err != nil {
 			t.Error(err)
 			t.FailNow()
 		}
 	}
 
-	err := compare(name, actualData)
+	err := g.compare(t, name, actualData)
 	if err != nil {
-		switch err.(type) {
-		case errFixtureNotFound:
-			t.Error(err)
-			t.FailNow()
-		case errFixtureMismatch:
-			t.Error(err)
-		default:
-			t.Error(err)
+		{
+			var e *errFixtureNotFound
+			if errors.As(err, &e) {
+				t.Error(err)
+				t.FailNow()
+				return
+			}
 		}
+
+		{
+			var e *errFixtureMismatch
+			if errors.As(err, &e) {
+				t.Error(err)
+				return
+			}
+		}
+
+		t.Error(err)
 	}
 }
 
@@ -81,7 +131,7 @@ func Assert(t *testing.T, name string, actualData []byte) {
 // `name` refers to the name of the test and it should typically be unique
 // within the package. Also it should be a valid file name (so keeping to
 // `a-z0-9\-\_` is a good idea).
-func AssertJson(t *testing.T, name string, actualJsonData interface{}) {
+func (g *goldie) AssertJson(t *testing.T, name string, actualJsonData interface{}) {
 	js, err := json.MarshalIndent(actualJsonData, "", "  ")
 
 	if err != nil {
@@ -89,7 +139,7 @@ func AssertJson(t *testing.T, name string, actualJsonData interface{}) {
 		t.FailNow()
 	}
 
-	Assert(t, name, normalizeLF(js))
+	g.Assert(t, name, normalizeLF(js))
 }
 
 // normalizeLF normalizes line feed character set across os (es)
@@ -112,26 +162,35 @@ func normalizeLF(d []byte) []byte {
 // `name` refers to the name of the test and it should typically be unique
 // within the package. Also it should be a valid file name (so keeping to
 // `a-z0-9\-\_` is a good idea).
-func AssertWithTemplate(t *testing.T, name string, data interface{}, actualData []byte) {
+func (g *goldie) AssertWithTemplate(t *testing.T, name string, data interface{}, actualData []byte) {
 	if *update {
-		err := Update(name, actualData)
+		err := g.Update(t, name, actualData)
 		if err != nil {
 			t.Error(err)
 			t.FailNow()
 		}
 	}
 
-	err := compareTemplate(name, data, actualData)
+	err := g.compareTemplate(t, name, data, actualData)
 	if err != nil {
-		switch err.(type) {
-		case errFixtureNotFound:
-			t.Error(err)
-			t.FailNow()
-		case errFixtureMismatch:
-			t.Error(err)
-		default:
-			t.Error(err)
+		{
+			var e *errFixtureNotFound
+			if errors.As(err, &e) {
+				t.Error(err)
+				t.FailNow()
+				return
+			}
 		}
+
+		{
+			var e *errFixtureMismatch
+			if errors.As(err, &e) {
+				t.Error(err)
+				return
+			}
+		}
+
+		t.Error(err)
 	}
 }
 
@@ -140,18 +199,18 @@ func AssertWithTemplate(t *testing.T, name string, data interface{}, actualData 
 // This method does not need to be called from code, but it's exposed so that it
 // can be explicitly called if needed. The more common approach would be to
 // update using `go test -update ./...`.
-func Update(name string, actualData []byte) error {
-	if err := ensureDir(filepath.Dir(goldenFileName(name))); err != nil {
+func (g *goldie) Update(t *testing.T, name string, actualData []byte) error {
+	if err := g.ensureDir(filepath.Dir(g.goldenFileName(t, name))); err != nil {
 		return err
 	}
 
-	return ioutil.WriteFile(goldenFileName(name), actualData, FilePerms)
+	return ioutil.WriteFile(g.goldenFileName(t, name), actualData, g.filePerms)
 }
 
 // compare is reading the golden fixture file and compare the stored data with
 // the actual data.
-func compare(name string, actualData []byte) error {
-	expectedData, err := ioutil.ReadFile(goldenFileName(name))
+func (g *goldie) compare(t *testing.T, name string, actualData []byte) error {
+	expectedData, err := ioutil.ReadFile(g.goldenFileName(t, name))
 
 	if err != nil {
 		if os.IsNotExist(err) {
@@ -162,21 +221,58 @@ func compare(name string, actualData []byte) error {
 	}
 
 	if !bytes.Equal(actualData, expectedData) {
-		return newErrFixtureMismatch(
-			fmt.Sprintf("Result did not match the golden fixture.\n"+
-				"Expected: %s\n"+
+		msg := "Result did not match the golden fixture.\n"
+		actual := string(actualData)
+		expected := string(expectedData)
+
+		if g.diffFn != nil || g.diffProcessor != UndefinedDiff {
+			var d string
+			if g.diffFn != nil {
+				d = g.diffFn(actual, expected)
+			} else {
+				d = diff(g.diffProcessor, actual, expected)
+			}
+
+			msg += "Diff is below:\n" + d
+		} else {
+			msg = fmt.Sprintf("%sExpected: %s\n"+
 				"Got: %s",
-				string(expectedData),
-				string(actualData)))
+				msg,
+				expected,
+				actual)
+		}
+		return newErrFixtureMismatch(msg)
 	}
 
 	return nil
 }
 
+func diff(engine DiffProcessor, actual string, expected string) string {
+	var diff string
+	switch engine {
+	case ClassicDiff:
+		diff, _ = difflib.GetUnifiedDiffString(difflib.UnifiedDiff{
+			A:        difflib.SplitLines(expected),
+			B:        difflib.SplitLines(actual),
+			FromFile: "Expected",
+			FromDate: "",
+			ToFile:   "Actual",
+			ToDate:   "",
+			Context:  1,
+		})
+
+	case ColoredDiff:
+		dmp := diffmatchpatch.New()
+		diffs := dmp.DiffMain(actual, expected, false)
+		diff = dmp.DiffPrettyText(diffs)
+	}
+	return diff
+}
+
 // compareTemplate is reading the golden fixture file and compare the stored
 // data with the actual data.
-func compareTemplate(name string, data interface{}, actualData []byte) error {
-	expectedDataTmpl, err := ioutil.ReadFile(goldenFileName(name))
+func (g *goldie) compareTemplate(t *testing.T, name string, data interface{}, actualData []byte) error {
+	expectedDataTmpl, err := ioutil.ReadFile(g.goldenFileName(t, name))
 
 	if err != nil {
 		if os.IsNotExist(err) {
@@ -186,7 +282,11 @@ func compareTemplate(name string, data interface{}, actualData []byte) error {
 		return fmt.Errorf("Expected %s to be nil", err.Error())
 	}
 
-	tmpl, err := template.New("test").Parse(string(expectedDataTmpl))
+	missingKey := "error"
+	if g.ignoreTemplateErrors {
+		missingKey = "default"
+	}
+	tmpl, err := template.New("test").Option("missingkey=" + missingKey).Parse(string(expectedDataTmpl))
 	if err != nil {
 		return fmt.Errorf("Expected %s to be nil", err.Error())
 	}
@@ -194,7 +294,7 @@ func compareTemplate(name string, data interface{}, actualData []byte) error {
 	var expectedData bytes.Buffer
 	err = tmpl.Execute(&expectedData, data)
 	if err != nil {
-		return fmt.Errorf("Expected %s to be nil", err.Error())
+		return newErrMissingKey(fmt.Sprintf("Template error: %s", err.Error()))
 	}
 
 	if !bytes.Equal(actualData, expectedData.Bytes()) {
@@ -210,12 +310,12 @@ func compareTemplate(name string, data interface{}, actualData []byte) error {
 }
 
 // ensureDir will create the fixture folder if it does not already exist.
-func ensureDir(loc string) error {
+func (g *goldie) ensureDir(loc string) error {
 	s, err := os.Stat(loc)
 	switch {
 	case err != nil && os.IsNotExist(err):
 		// the location does not exist, so make directories to there
-		return os.MkdirAll(loc, DirPerms)
+		return os.MkdirAll(loc, g.dirPerms)
 	case err == nil && !s.IsDir():
 		return newErrFixtureDirectoryIsFile(loc)
 	}
@@ -224,6 +324,21 @@ func ensureDir(loc string) error {
 }
 
 // goldenFileName simply returns the file name of the golden file fixture.
-func goldenFileName(name string) string {
-	return filepath.Join(FixtureDir, fmt.Sprintf("%s%s", name, FileNameSuffix))
+func (g *goldie) goldenFileName(t *testing.T, name string) string {
+
+	dir := g.fixtureDir
+
+	if g.useTestNameForDir {
+		dir = filepath.Join(dir, strings.Split(t.Name(), "/")[0])
+	}
+
+	if g.useSubTestNameForDir {
+		n := strings.Split(t.Name(), "/")
+		if len(n) > 1 {
+
+			dir = filepath.Join(dir, n[1])
+		}
+	}
+
+	return filepath.Join(dir, fmt.Sprintf("%s%s", name, g.fileNameSuffix))
 }

--- a/goldie.go
+++ b/goldie.go
@@ -26,8 +26,8 @@ import (
 )
 
 // Compile time assurance
-var _ Tester = &goldie{}
-var _ OptionProcessor = &goldie{}
+var _ Tester = (*goldie)(nil)
+var _ OptionProcessor = (*goldie)(nil)
 
 type goldie struct {
 	fixtureDir     string

--- a/goldie_test.go
+++ b/goldie_test.go
@@ -285,7 +285,7 @@ func TestNormalizeLF(t *testing.T) {
 
 func TestDiffEngines(t *testing.T) {
 	type engine struct {
-		engine DiffProcessor
+		engine DiffEngine
 		diff   string
 	}
 
@@ -313,7 +313,7 @@ func TestDiffEngines(t *testing.T) {
 
 	for _, tt := range tests {
 		for _, e := range tt.engines {
-			diff := diff(e.engine, tt.actual, tt.expected)
+			diff := Diff(e.engine, tt.actual, tt.expected)
 			assert.Equal(t, e.diff, diff)
 		}
 	}

--- a/interface.go
+++ b/interface.go
@@ -44,7 +44,7 @@ type Tester interface {
 	Assert(t *testing.T, name string, actualData []byte)
 	AssertJson(t *testing.T, name string, actualJsonData interface{})
 	AssertWithTemplate(t *testing.T, name string, data interface{}, actualData []byte)
-	Update(name string, actualData []byte) error
+	Update(t *testing.T, name string, actualData []byte) error
 }
 
 // DiffFn takes in an actual and expected and will return a diff string

--- a/interface.go
+++ b/interface.go
@@ -13,6 +13,9 @@ import (
 	"fmt"
 	"os"
 	"testing"
+
+	"github.com/pmezard/go-difflib/difflib"
+	"github.com/sergi/go-diff/diffmatchpatch"
 )
 
 const (
@@ -38,8 +41,11 @@ var (
 	update = flag.Bool("update", false, "Update golden test file fixture")
 )
 
+// Option defines the signature of a functional option method that can
+// apply options to an OptionProcessor.
 type Option func(OptionProcessor) error
 
+// Tester defines the methods that any golden tester should support.
 type Tester interface {
 	Assert(t *testing.T, name string, actualData []byte)
 	AssertJson(t *testing.T, name string, actualJsonData interface{})
@@ -48,29 +54,130 @@ type Tester interface {
 }
 
 // DiffFn takes in an actual and expected and will return a diff string
-// representing the differences between the two
+// representing the differences between the two.
 type DiffFn func(actual string, expected string) string
-type DiffProcessor int
+
+// DiffEngine is used to enumerate the diff engine processors that are available
+type DiffEngine int
 
 const (
-	UndefinedDiff DiffProcessor = iota
+	// UndefinedDiff represents any undefined diff processor.  If a new diff engine
+	// is implemented, it should be added to this enumeration and to the `diff` helper
+	// function.
+	UndefinedDiff DiffEngine = iota
+
+	// ClassicDiff produces a diff similar to what the `diff` tool would produce.
+	//		+++ Actual
+	//		@@ -1 +1 @@
+	//		-Lorem dolor sit amet.
+	//		+Lorem ipsum dolor.
+	//
 	ClassicDiff
+
+	// ColoredDiff produces a diff that will use red and green colors to distinguish
+	// the diffs between the two values.
 	ColoredDiff
 )
 
+// OptionProcessor defines the functions that can be called to set values for
+// a tester.  To expand this list, add a function to this interface and then
+// implement the generic option setter below.
 type OptionProcessor interface {
+	// WithFixtureDir sets the directory that will be used to store the fixtures.
+	// Defaults to `testdata`.
 	WithFixtureDir(dir string) error
 	WithNameSuffix(suffix string) error
 	WithFilePerms(mode os.FileMode) error
 	WithDirPerms(mode os.FileMode) error
 
-	WithDiffEngine(engine DiffProcessor) error
+	WithDiffEngine(engine DiffEngine) error
 	WithDiffFn(fn DiffFn) error
 	WithIgnoreTemplateErrors(ignoreErrors bool) error
 	WithTestNameForDir(use bool) error
 	WithSubTestNameForDir(use bool) error
 }
 
+// === OptionProcessor ===============================
+
+func WithFixtureDir(dir string) Option {
+	return func(o OptionProcessor) error {
+		return o.WithFixtureDir(dir)
+	}
+}
+
+// WithNameSuffix sets the file suffix to be used for the golden file.
+// Defaults to `.golden`
+func WithNameSuffix(suffix string) Option {
+	return func(o OptionProcessor) error {
+		return o.WithNameSuffix(suffix)
+	}
+}
+
+// WithFilePerms sets the file permissions on the golden files that
+// are created.  Defaults to 0644.
+func WithFilePerms(mode os.FileMode) Option {
+	return func(o OptionProcessor) error {
+		return o.WithFilePerms(mode)
+	}
+}
+
+// WithDirPerms sets the directory permissions for the directories
+// in which the golden files are created.  Defaults to 0755.
+func WithDirPerms(mode os.FileMode) Option {
+	return func(o OptionProcessor) error {
+		return o.WithDirPerms(mode)
+	}
+}
+
+// WithDiffEngine sets the `diff` engine that will be used to generate
+// the `diff` text.
+func WithDiffEngine(engine DiffEngine) Option {
+	return func(o OptionProcessor) error {
+		return o.WithDiffEngine(engine)
+	}
+}
+
+// WithDiffFn sets the `diff` engine to be a function that implements
+// the DiffFn signature.  This allows for any customized diff logic
+// you would like to create.
+func WithDiffFn(fn DiffFn) Option {
+	return func(o OptionProcessor) error {
+		return o.WithDiffFn(fn)
+	}
+}
+
+// WithIgnoreTemplateErrors allows template processing to ignore any variables
+// in the template that do not have corresponding data values passed in.
+// Default value is false.
+func WithIgnoreTemplateErrors(ignoreErrors bool) Option {
+	return func(o OptionProcessor) error {
+		return o.WithIgnoreTemplateErrors(ignoreErrors)
+	}
+}
+
+// WithTestNameForDir will create a directory with the test's name
+// in the fixture directory to store all the golden files.
+func WithTestNameForDir(use bool) Option {
+	return func(o OptionProcessor) error {
+		return o.WithTestNameForDir(use)
+	}
+}
+
+// WithSubTestNameForDir will create a directory with the sub test's name
+// to store all the golden files.  If WithTestNameForDir is enabled,
+// it will be in the test name's directory.  Otherwise, it will be in the
+// fixture directory.
+func WithSubTestNameForDir(use bool) Option {
+	return func(o OptionProcessor) error {
+		return o.WithSubTestNameForDir(use)
+	}
+}
+
+// === Create new testers ==================================
+
+// New creates a new golden file tester.  If there is an issue
+// with applying any of the options, an error will be
+// reported and t.FailNow() will be called.
 func New(t *testing.T, options ...Option) *goldie {
 	g := goldie{
 		fixtureDir:     defaultFixtureDir,
@@ -84,58 +191,34 @@ func New(t *testing.T, options ...Option) *goldie {
 		err = option(&g)
 		if err != nil {
 			t.Error(fmt.Errorf("Could not apply option: %w", err))
+			t.FailNow()
 		}
 	}
 
 	return &g
 }
 
-// === OptionProcessor ===============================
+// Diff generates a string that shows the difference between the actual
+// and the expected.  This method could be called in your own DiffFn
+// in case you want to leverage any of the engines defined.
+func Diff(engine DiffEngine, actual string, expected string) string {
+	var diff string
+	switch engine {
+	case ClassicDiff:
+		diff, _ = difflib.GetUnifiedDiffString(difflib.UnifiedDiff{
+			A:        difflib.SplitLines(expected),
+			B:        difflib.SplitLines(actual),
+			FromFile: "Expected",
+			FromDate: "",
+			ToFile:   "Actual",
+			ToDate:   "",
+			Context:  1,
+		})
 
-func WithFixtureDir(dir string) Option {
-	return func(o OptionProcessor) error {
-		return o.WithFixtureDir(dir)
+	case ColoredDiff:
+		dmp := diffmatchpatch.New()
+		diffs := dmp.DiffMain(actual, expected, false)
+		diff = dmp.DiffPrettyText(diffs)
 	}
-}
-
-func WithNameSuffix(suffix string) Option {
-	return func(o OptionProcessor) error {
-		return o.WithNameSuffix(suffix)
-	}
-}
-
-func WithFilePerms(mode os.FileMode) Option {
-	return func(o OptionProcessor) error {
-		return o.WithFilePerms(mode)
-	}
-}
-
-func WithDirPerms(mode os.FileMode) Option {
-	return func(o OptionProcessor) error {
-		return o.WithDirPerms(mode)
-	}
-}
-
-func WithDiffEngine(engine DiffProcessor) Option {
-	return func(o OptionProcessor) error {
-		return o.WithDiffEngine(engine)
-	}
-}
-
-func WithIgnoreTemplateErrors(ignoreErrors bool) Option {
-	return func(o OptionProcessor) error {
-		return o.WithIgnoreTemplateErrors(ignoreErrors)
-	}
-}
-
-func WithTestNameForDir(use bool) Option {
-	return func(o OptionProcessor) error {
-		return o.WithTestNameForDir(use)
-	}
-}
-
-func WithSubTestNameForDir(use bool) Option {
-	return func(o OptionProcessor) error {
-		return o.WithSubTestNameForDir(use)
-	}
+	return diff
 }

--- a/interface.go
+++ b/interface.go
@@ -1,0 +1,141 @@
+// Package goldie provides test assertions based on golden files. It's typically
+// used for testing responses with larger data bodies.
+//
+// The concept is straight forward. Valid response data is stored in a "golden
+// file". The actual response data will be byte compared with the golden file
+// and the test will fail if there is a difference.
+//
+// Updating the golden file can be done by running `go test -update ./...`.
+package goldie
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"testing"
+)
+
+const (
+	// FixtureDir is the folder name for where the fixtures are stored. It's
+	// relative to the "go test" path.
+	defaultFixtureDir = "testdata"
+
+	// FileNameSuffix is the suffix appended to the fixtures. Set to empty
+	// string to disable file name suffixes.
+	defaultFileNameSuffix = ".golden"
+
+	// FilePerms is used to set the permissions on the golden fixture files.
+	defaultFilePerms os.FileMode = 0644
+
+	// DirPerms is used to set the permissions on the golden fixture folder.
+	defaultDirPerms os.FileMode = 0755
+)
+
+var (
+	// update determines if the actual received data should be written to the
+	// golden files or not. This should be true when you need to update the
+	// data, but false when actually running the tests.
+	update = flag.Bool("update", false, "Update golden test file fixture")
+)
+
+type Option func(OptionProcessor) error
+
+type Tester interface {
+	Assert(t *testing.T, name string, actualData []byte)
+	AssertJson(t *testing.T, name string, actualJsonData interface{})
+	AssertWithTemplate(t *testing.T, name string, data interface{}, actualData []byte)
+	Update(name string, actualData []byte) error
+}
+
+// DiffFn takes in an actual and expected and will return a diff string
+// representing the differences between the two
+type DiffFn func(actual string, expected string) string
+type DiffProcessor int
+
+const (
+	UndefinedDiff DiffProcessor = iota
+	ClassicDiff
+	ColoredDiff
+)
+
+type OptionProcessor interface {
+	WithFixtureDir(dir string) error
+	WithNameSuffix(suffix string) error
+	WithFilePerms(mode os.FileMode) error
+	WithDirPerms(mode os.FileMode) error
+
+	WithDiffEngine(engine DiffProcessor) error
+	WithDiffFn(fn DiffFn) error
+	WithIgnoreTemplateErrors(ignoreErrors bool) error
+	WithTestNameForDir(use bool) error
+	WithSubTestNameForDir(use bool) error
+}
+
+func New(t *testing.T, options ...Option) *goldie {
+	g := goldie{
+		fixtureDir:     defaultFixtureDir,
+		fileNameSuffix: defaultFileNameSuffix,
+		filePerms:      defaultFilePerms,
+		dirPerms:       defaultDirPerms,
+	}
+
+	var err error
+	for _, option := range options {
+		err = option(&g)
+		if err != nil {
+			t.Error(fmt.Errorf("Could not apply option: %w", err))
+		}
+	}
+
+	return &g
+}
+
+// === OptionProcessor ===============================
+
+func WithFixtureDir(dir string) Option {
+	return func(o OptionProcessor) error {
+		return o.WithFixtureDir(dir)
+	}
+}
+
+func WithNameSuffix(suffix string) Option {
+	return func(o OptionProcessor) error {
+		return o.WithNameSuffix(suffix)
+	}
+}
+
+func WithFilePerms(mode os.FileMode) Option {
+	return func(o OptionProcessor) error {
+		return o.WithFilePerms(mode)
+	}
+}
+
+func WithDirPerms(mode os.FileMode) Option {
+	return func(o OptionProcessor) error {
+		return o.WithDirPerms(mode)
+	}
+}
+
+func WithDiffEngine(engine DiffProcessor) Option {
+	return func(o OptionProcessor) error {
+		return o.WithDiffEngine(engine)
+	}
+}
+
+func WithIgnoreTemplateErrors(ignoreErrors bool) Option {
+	return func(o OptionProcessor) error {
+		return o.WithIgnoreTemplateErrors(ignoreErrors)
+	}
+}
+
+func WithTestNameForDir(use bool) Option {
+	return func(o OptionProcessor) error {
+		return o.WithTestNameForDir(use)
+	}
+}
+
+func WithSubTestNameForDir(use bool) Option {
+	return func(o OptionProcessor) error {
+		return o.WithSubTestNameForDir(use)
+	}
+}


### PR DESCRIPTION
This version of goldie follows the functional options pattern:  
  https://dave.cheney.net/2014/10/17/functional-options-for-friendly-apis

It allows for easy, independent configuration of the goldie object, allowing each test case to leverage different options while running in parallel.  In addition to the restructuring, a new `DiffEngine` option was added.  This allows you to choose `ClassicDiff` or `ColoredDiff` to see the difference in the golden files, or you could even use the `DiffFn` option to implement your own diff function.

Errors were also updated to use pointer receivers instead of value receivers.  This is the pattern that Go uses internally.  In addition, the new `errors` package from Go v1.13 was incorporated.  This will require those using this package to compile with Go v1.13 or higher.

This PR will close out #8 and #10 .