### PR TITLE
[feature] Reference testing.T once only

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ func TestExample(t *testing.T) {
     handler.ServeHTTP()
 
     g := goldie.New(t)
-    g.Assert(t, "example", recorder.Body.Bytes())
+    g.Assert("example", recorder.Body.Bytes())
 }
 ```
 
@@ -65,7 +65,7 @@ func TestTemplateExample(t *testing.T) {
     }
 
     g := goldie.New(t)
-    g.AssertWithTemplate(t, "example", data, recorder.Body.Bytes())
+    g.AssertWithTemplate("example", data, recorder.Body.Bytes())
 }
 ```
 
@@ -92,7 +92,7 @@ func TestNewExample(t *testing.T) {
         goldie.WithTestNameForDir(true),
     )
 
-    g.Assert(t, "example", []byte("my example data"))
+    g.Assert("example", []byte("my example data"))
 }
 
 ```

--- a/interface.go
+++ b/interface.go
@@ -2,7 +2,6 @@ package goldie
 
 import (
 	"os"
-	"testing"
 )
 
 // Compile time assurance
@@ -15,10 +14,10 @@ type Option func(OptionProcessor) error
 
 // Tester defines the methods that any golden tester should support.
 type Tester interface {
-	Assert(t *testing.T, name string, actualData []byte)
-	AssertJson(t *testing.T, name string, actualJsonData interface{})
-	AssertWithTemplate(t *testing.T, name string, data interface{}, actualData []byte)
-	Update(t *testing.T, name string, actualData []byte) error
+	Assert(name string, actualData []byte)
+	AssertJson(name string, actualJsonData interface{})
+	AssertWithTemplate(name string, data interface{}, actualData []byte)
+	Update(name string, actualData []byte) error
 }
 
 // DiffFn takes in an actual and expected and will return a diff string


### PR DESCRIPTION
This change makes the reference to `*testing.T` required _only_ when calling `goldie.New()`. For the sub-sequent `Assert*()`, the passing of `*testing.T` is
not required.

This makes the users code less verbose as fewer parameters are required for the assertions.