### PR TITLE
[feature] Clear fixture directory before generating new golden files

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,15 @@ drop the `-update` flag.
 
 `go test ./...`
 
+## Flags
+
+### Clean output directory
+
+Using `-update` along with `-clean` flag will clear the fixture directory before updating golden files.
+
+`go test -update -clean ./...`
+
+
 ## Options
 
 `goldie` supports a number of configuration options that will alter the behavior


### PR DESCRIPTION
Hi all, this PR intends to improve issue #19.

Sometimes if we update test cases that affect the golden files' names and then run `go test -update`, the old named files are left untouched.

This PR presents `-clean` flag, which will clear and recreate output directory of golden files.