### PR TITLE
Do not escape JSON

### DIFF
--- a/v2/assertions.go
+++ b/v2/assertions.go
@@ -61,14 +61,18 @@ func (g *Goldie) Assert(t *testing.T, name string, actualData []byte) {
 // `a-z0-9\-\_` is a good idea).
 func (g *Goldie) AssertJson(t *testing.T, name string, actualJsonData interface{}) {
 	t.Helper()
-	js, err := json.MarshalIndent(actualJsonData, "", "  ")
+	buf := &bytes.Buffer{}
+	enc := json.NewEncoder(buf)
+	enc.SetIndent("", "  ")
+	enc.SetEscapeHTML(false)
+	err := enc.Encode(actualJsonData)
 
 	if err != nil {
 		t.Error(err)
 		t.FailNow()
 	}
 
-	g.Assert(t, name, normalizeLF(js))
+	g.Assert(t, name, normalizeLF(buf.Bytes()))
 }
 
 // AssertXml compares the actual xml data received with expected data in the


### PR DESCRIPTION
`encoding/json` escapes &, <, and > by default. This is not useful for golden tests and only makes the output harder to read.