### PR TITLE
Accept sub sub test name for dir

### DIFF
--- a/v2/goldie.go
+++ b/v2/goldie.go
@@ -199,7 +199,7 @@ func (g *Goldie) GoldenFileName(t *testing.T, name string) string {
 	if g.useSubTestNameForDir {
 		n := strings.Split(t.Name(), "/")
 		if len(n) > 1 {
-			dir = filepath.Join(dir, n[1])
+			dir = filepath.Join(append([]string{dir}, n[1:]...)...)
 		}
 	}
 

--- a/v2/goldie_test.go
+++ b/v2/goldie_test.go
@@ -50,6 +50,13 @@ func TestGoldenFileName(t *testing.T) {
 			},
 			expected: fmt.Sprintf("%s/%s/%s%s", defaultFixtureDir, "using_sub_test_name_for_dir", "example", defaultFileNameSuffix),
 		},
+		"using sub/sub test name for dir": {
+			name: "example",
+			options: []Option{
+				WithSubTestNameForDir(true),
+			},
+			expected: fmt.Sprintf("%s/%s/%s/%s%s", defaultFixtureDir, "using_sub", "sub_test_name_for_dir", "example", defaultFileNameSuffix),
+		},
 	}
 
 	for name, test := range tests {


### PR DESCRIPTION
Really helpfull in case of a testify test suite, where test name can be in three parts:

```
TestSuite/Test/Run
```