### PR TITLE
Add customizable equality compare option

### DIFF
--- a/v2/README.md
+++ b/v2/README.md
@@ -136,6 +136,7 @@ func TestNewExample(t *testing.T) {
 | `WithNameSuffix`           | Suffix for fixture files.                                | `.golden`
 | `WithDirPerms`             | Directory permissions for fixtures                       | `0755`
 | `WithFilePerms`            | File permissions for fixtures                            | `0644`
+| `WithEqualFn`              | Custom equal logic to be used                            | None
 | `WithDiffEngine`           | Diff engine to use for diff output                       | `ClassicDiff`
 | `WithDiffFn`               | Custom diff logic to be used                             | None
 | `WithIgnoreTemplateErrors` | Ignore errors from templates                             | `false`

--- a/v2/assertions.go
+++ b/v2/assertions.go
@@ -156,7 +156,7 @@ func (g *Goldie) compare(t *testing.T, name string, actualData []byte) error {
 		return fmt.Errorf("expected %s to be nil", err.Error())
 	}
 
-	if !bytes.Equal(actualData, expectedData) {
+	if !g.equal(actualData, expectedData) {
 		msg := "Result did not match the golden fixture. Diff is below:\n\n"
 		actual := string(actualData)
 		expected := string(expectedData)
@@ -202,7 +202,7 @@ func (g *Goldie) compareTemplate(t *testing.T, name string, data interface{}, ac
 		return newErrMissingKey(fmt.Sprintf("Template error: %s", err.Error()))
 	}
 
-	if !bytes.Equal(actualData, expectedData.Bytes()) {
+	if !g.equal(actualData, expectedData.Bytes()) {
 		msg := "Result did not match the golden fixture. Diff is below:\n\n"
 		actual := string(actualData)
 		expected := expectedData.String()
@@ -217,4 +217,11 @@ func (g *Goldie) compareTemplate(t *testing.T, name string, data interface{}, ac
 	}
 
 	return nil
+}
+
+func (g *Goldie) equal(actual, expected []byte) bool {
+	if g.equalFn != nil {
+		return g.equalFn(actual, expected)
+	}
+	return bytes.Equal(actual, expected)
 }

--- a/v2/assertions_test.go
+++ b/v2/assertions_test.go
@@ -14,6 +14,7 @@ func TestCompare(t *testing.T) {
 		actualData   []byte
 		expectedData []byte
 		update       bool
+		equalfn      EqualFn
 		err          error
 	}{
 		{
@@ -21,6 +22,7 @@ func TestCompare(t *testing.T) {
 			actualData:   []byte("abc"),
 			expectedData: []byte("abc"),
 			update:       true,
+			equalfn:      nil,
 			err:          nil,
 		},
 		{
@@ -28,6 +30,7 @@ func TestCompare(t *testing.T) {
 			actualData:   []byte("abc"),
 			expectedData: []byte("abc"),
 			update:       false,
+			equalfn:      nil,
 			err:          &errFixtureNotFound{},
 		},
 		{
@@ -35,13 +38,25 @@ func TestCompare(t *testing.T) {
 			actualData:   []byte("bc"),
 			expectedData: []byte("abc"),
 			update:       true,
+			equalfn:      nil,
 			err:          &errFixtureMismatch{},
+		},
+		{
+			name:         "custom equalfn",
+			actualData:   []byte("ab"),
+			expectedData: []byte("abc"),
+			update:       true,
+			equalfn: func(actual, expected []byte) bool {
+				return actual[0] == expected[0]
+			},
+			err: nil,
 		},
 		{
 			name:         "nil",
 			actualData:   nil,
 			expectedData: nil,
 			update:       true,
+			equalfn:      nil,
 			err:          nil,
 		},
 	}
@@ -54,6 +69,7 @@ func TestCompare(t *testing.T) {
 			assert.Nil(t, err)
 		}
 
+		g.equalFn = test.equalfn
 		err := g.compare(t, test.name, test.actualData)
 		assert.IsType(t, test.err, err)
 

--- a/v2/goldie.go
+++ b/v2/goldie.go
@@ -80,6 +80,7 @@ type Goldie struct {
 	filePerms      os.FileMode
 	dirPerms       os.FileMode
 
+	equalFn              EqualFn
 	diffEngine           DiffEngine
 	diffFn               DiffFn
 	ignoreTemplateErrors bool

--- a/v2/interface.go
+++ b/v2/interface.go
@@ -23,6 +23,9 @@ type Tester interface {
 	GoldenFileName(t *testing.T, name string) string
 }
 
+// EqualFn compares if actual and expected are equal.
+type EqualFn func(actual []byte, expected []byte) bool
+
 // DiffFn takes in an actual and expected and will return a diff string
 // representing the differences between the two.
 type DiffFn func(actual string, expected string) string
@@ -68,6 +71,7 @@ type OptionProcessor interface {
 	WithFilePerms(mode os.FileMode) error
 	WithDirPerms(mode os.FileMode) error
 
+	WithEqualFn(fn EqualFn) error
 	WithDiffEngine(engine DiffEngine) error
 	WithDiffFn(fn DiffFn) error
 	WithIgnoreTemplateErrors(ignoreErrors bool) error
@@ -114,6 +118,15 @@ func WithFilePerms(mode os.FileMode) Option {
 func WithDirPerms(mode os.FileMode) Option {
 	return func(o OptionProcessor) error {
 		return o.WithDirPerms(mode)
+	}
+}
+
+// WithEqualFn sets the customized equality comapre function that implements
+// the EqualFn signature.
+//noinspection GoUnusedExportedFunction
+func WithEqualFn(fn EqualFn) Option {
+	return func(o OptionProcessor) error {
+		return o.WithEqualFn(fn)
 	}
 }
 

--- a/v2/options.go
+++ b/v2/options.go
@@ -36,6 +36,13 @@ func (g *Goldie) WithDirPerms(mode os.FileMode) error {
 	return nil
 }
 
+// WithEqualFn sets the customized equality comapre function that implements
+// the EqualFn signature.
+func (g *Goldie) WithEqualFn(fn EqualFn) error {
+	g.equalFn = fn
+	return nil
+}
+
 // WithDiffEngine sets the `diff` engine that will be used to generate the
 // `diff` text.
 func (g *Goldie) WithDiffEngine(engine DiffEngine) error {


### PR DESCRIPTION
Thank you for this great library.
I've added the WithEqualFn option. By allowing users to use customizable comparison functions, this is particularly useful in scenarios where you don't want to compare the entire file.

This PR resolves https://github.com/sebdah/goldie/issues/27