### PR TITLE
Don't remove nested subdirectories

### DIFF
--- a/v2/goldie.go
+++ b/v2/goldie.go
@@ -176,7 +176,7 @@ func (g *Goldie) ensureDir(loc string) error {
 		// the location does not exist, so make directories to there
 		return os.MkdirAll(loc, g.dirPerms)
 
-	case err == nil && s.IsDir() && *clean && s.ModTime().UnixNano() != ts.UnixNano():
+	case err == nil && s.IsDir() && *clean && s.ModTime().UnixNano() < ts.UnixNano():
 		if err := os.RemoveAll(loc); err != nil {
 			return err
 		}


### PR DESCRIPTION
An alternative implementation to https://github.com/sebdah/goldie/pull/42 that maybe solves issues with removing old test output.

The problem can be described with this example:

If we write an output file to `fixture/a/b/c/foo.bar`, currently we will set the directory modification time of `c` to the value of the variable `ts`, this also changes the modification time for every parent of `c`. Which means that if we also run a test in `b` we will see a later modification time for the folder `b` and hence clean that directory, removing `c` and any output in `b`.

An alternative solution to this problem (other than the one given in this PR) could be to set the directory modification time for every directory between fixtureDir and the test dir. i.e. in the example above, when writing output to `c`, set the modification timestamp for `b` and `a` as well.
