### PR TITLE
feat: updated AssertWithTemplate to generate fixtures with variables when using the -update flag

### DIFF
--- a/v2/assertions.go
+++ b/v2/assertions.go
@@ -113,7 +113,7 @@ func normalizeLF(d []byte) []byte {
 func (g *Goldie) AssertWithTemplate(t *testing.T, name string, data interface{}, actualData []byte) {
 	t.Helper()
 	if *update {
-		err := g.Update(t, name, actualData)
+		err := g.UpdateWithTemplate(t, name, data, actualData)
 		if err != nil {
 			t.Error(err)
 			t.FailNow()

--- a/v2/assertions_test.go
+++ b/v2/assertions_test.go
@@ -125,7 +125,16 @@ func TestCompareTemplate(t *testing.T) {
 			data:         nil,
 			update:       true,
 			err:          &errMissingKey{},
-		}}
+		},
+		{
+			name:         "example",
+			actualData:   []byte("abc example"),
+			expectedData: []byte("abc {{ index (.) 1 }}"),
+			data:         []interface{}{"abc", "example"},
+			update:       true,
+			err:          nil,
+		},
+	}
 
 	g := New(t)
 


### PR DESCRIPTION
Fixes #14 and resolves the problems mentioned in https://github.com/go-task/task/pull/2265.

_This PR is a rough draft pending feedback on the implementation._

Currently, if you have a golden file containing variables, when you run `go test . -update`, the variables will be updated with the values given in the tests. This means that subsequent tests can fail depending on the data that is being passed in.

This PR updates the behavior of the `AssertWithTemplate` function so that it can generate new variables in the golden file based on the data type being passed in. This works by analysing the data using the `reflect` package and creating a map of values to their paths in the data type. The generated paths are based on go templating syntax so that when we update the golden file, we can perform a `bytes.ReplaceAll` on the data.

## Example

```go
func TestExample(t *testing.T) {
	g := goldie.New(t)
	wd, err := os.Getwd()
	require.NoError(t, err)
	data := map[string]any{
		"TEST_NAME": t.Name(),
		"TEST_DIR":  wd,
	}
	// "TestExample" matches "t.Name()" and so is replaced with the path to the variable
	g.AssertWithTemplate(t, "example", data, []byte("example TestExample"))
}
```

`go test -update ./...` Generates:

```
example {{.TEST_NAME}}
```

## Notes

- This works well with scalars, collections and nested structures
- Values with the highest specificity will be replaced first
  - Basically values that are longer before shorter ones. e.g. "foobar" before "foo" so you don't end up with "{{.FOO}}bar"
- Its worth considering if this is a backwards-compatiable change or not. Maybe we need a new function instead of updating `AssertWithTemplate`?
- Small values in data will cause issues. For example, a `map[string]string{"A": "a"}` will cause all instances of the letter "a" to be replaced. This could be undesirable. I would argue the tester should just choose more specific strings and the problem goes away.