### PR TITLE
feat: enable update and clean flags using environment variables

### DIFF
--- a/v2/goldie.go
+++ b/v2/goldie.go
@@ -59,12 +59,12 @@ var (
 	// update determines if the actual received data should be written to the
 	// golden files or not. This should be true when you need to update the
 	// data, but false when actually running the tests.
-	update = flag.Bool("update", false, "Update golden test file fixture")
+	update = flag.Bool("update", truthy(os.Getenv("GOLDIE_UPDATE")), "Update golden test file fixture")
 
 	// clean determines if we should remove old golden test files in the output
 	// directory or not. This only takes effect if we are updating the golden
 	// test files.
-	clean = flag.Bool("clean", false, "Clean old golden test files before writing new olds")
+	clean = flag.Bool("clean", truthy(os.Getenv("GOLDIE_CLEAN")), "Clean old golden test files before writing new olds")
 
 	// ts saves the timestamp of the test run, we use ts to mark the
 	// modification time of golden file dirs, for cleaning if required by
@@ -205,4 +205,13 @@ func (g *Goldie) GoldenFileName(t *testing.T, name string) string {
 	}
 
 	return filepath.Join(dir, fmt.Sprintf("%s%s", name, g.fileNameSuffix))
+}
+
+func truthy(s string) bool {
+	switch strings.ToLower(s) {
+	case "1", "true", "t":
+		return true
+	default:
+		return false
+	}
 }


### PR DESCRIPTION
Inspired by https://github.com/bradleyjkemp/cupaloy.

This solves the issues like #26 where the `-update` flag is unreliable or does not work on packages that do not contain Goldie tests. Instead of specifying the `-update` flag, they can set an environment variable which will work with any `go test` command.

At the moment, I have to specify a list of all the packages I want to test and pass the `-update` flag to each. After this change, you will be able to set the variable once and use the variadic parameter to run all your tests whether they use Goldie or not. e.g.

`GOLDIE_UPDATE=true go test ./...`
