### PR TITLE
Add v2 tests to CI

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -18,8 +18,18 @@ jobs:
     - name: Check out code into the Go module directory
       uses: actions/checkout@v2
 
-    - name: Build
+    - name: Build v1
       run: go build -v .
 
-    - name: Test
+    - name: Test v1
       run: go test -v ./...
+
+    - name: Build v2
+      run: |
+        cd v2
+        go build -v .
+
+    - name: Test v2
+      run: |
+        cd v2
+        go test -v ./...

--- a/v2/goldie_test.go
+++ b/v2/goldie_test.go
@@ -521,6 +521,8 @@ func TestCleanFunction(t *testing.T) {
 	}
 
 	*clean = true
+	// Ensure filesystem timestamps increase enough to trigger cleaning logic
+	time.Sleep(2 * time.Second)
 	ts = time.Now()
 
 	// The second time running go test, with -update and -clean


### PR DESCRIPTION
## Summary
- run build and tests for module v2 in workflow
- fix non-deterministic timestamp in v2 clean test
- rename v1 steps for clarity in workflow

## Testing
- `go test -mod=vendor ./...`
- `cd v2 && go test -mod=vendor ./...`


------
https://chatgpt.com/codex/tasks/task_e_686e52ab70b883228fef786935287776